### PR TITLE
ci(Actions): Include hotfix branches as triggers for Test PR

### DIFF
--- a/.github/workflows/push-and-PR-test.yaml
+++ b/.github/workflows/push-and-PR-test.yaml
@@ -4,7 +4,7 @@ on:
     branches: [release,dev,master]
     paths-ignore: ['doc/**','**.md','.gitignore','Prototype/**']
   push:
-    branches: [feature/**]
+    branches: [feature/**,hotfix/**]
     paths-ignore: ['doc/**','**.md','.gitignore','Prototype/**']
 jobs:
   build:
@@ -26,4 +26,4 @@ jobs:
     - name: Run Dart Analyzer
       run: flutter analyze .
     - name: Attempt release build generation
-      run: flutter build apk --split-per-abi
+      run: flutter build apk --target-platform android-arm,android-arm64 --obfuscate --split-debug-info=./ez_tickets_app/debug_trace


### PR DESCRIPTION
This PR also updated the release workflow with the following changes:

- Use relative path for stack-trace-output
- Set target platforms of release apk to arm v7a and v8a
- Filter arm apks to upload as artifacts

Signed-off-by: arafaysaleem <a.rafaysaleem@gmail.com>