### PR TITLE
ci(Actions): Fix token for bump tag action in release workflow

### DIFF
--- a/.github/workflows/PR-merge-build-release.yaml
+++ b/.github/workflows/PR-merge-build-release.yaml
@@ -34,7 +34,7 @@ jobs:
       id: generate_tag
       uses: mathieudutour/github-tag-action@v5.5
       with:
-        github_token: ${{ secrets.EZ_TICKETS_APP_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         default_bump: minor # major, minor, patch, false
         custom_release_rules: "chore:patch:Chore Tasks,hotfix:minor:Bug Fixes,refact:patch:Refactors,docs:patch:Documentation Changes,build:patch:Build System/Dependency Upgrades"
     - name: Upload release apk to artifacts
@@ -42,8 +42,8 @@ jobs:
       with:
         tag: "${{ steps.generate_tag.outputs.new_tag }}"
         artifacts: "build/app/outputs/apk/release/app-arm*.apk"
-        name: Release ${{ steps.generate_tag.outputs.new_tag }}
-        body: ${{ steps.generate_tag.outputs.changelog }}
+        name: "Release ${{ steps.generate_tag.outputs.new_tag }}"
+        body: "${{ steps.generate_tag.outputs.changelog }}"
         token: ${{ secrets.EZ_TICKETS_APP_TOKEN }}
     - name: Upload apks to google drive
       uses: mkrakowitzer/actions-googledrive@1


### PR DESCRIPTION
This PR tries to use the default GITHUB_TOKEN for bump tag action

Signed-off-by: arafaysaleem <a.rafaysaleem@gmail.com>