### PR TITLE
ci(Actions): Fix token for upload artifact action in release workflow

### DIFF
--- a/.github/workflows/PR-merge-build-release.yaml
+++ b/.github/workflows/PR-merge-build-release.yaml
@@ -36,7 +36,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         default_bump: minor # major, minor, patch, false
-        custom_release_rules: "chore:patch:Chore Tasks,hotfix:minor:Bug Fixes,refact:patch:Refactors,docs:patch:Documentation Changes,build:patch:Build System/Dependency Upgrades"
+        custom_release_rules: "ci:patch:CI/CD,chore:patch:Chore Tasks,hotfix:minor:Bug Fixes,refact:patch:Refactors,docs:patch:Documentation Changes,build:patch:Build System/Dependency Upgrades"
     - name: Upload release apk to artifacts
       uses: ncipollo/release-action@v1.8.6
       with:
@@ -44,7 +44,7 @@ jobs:
         artifacts: "build/app/outputs/apk/release/app-arm*.apk"
         name: "Release ${{ steps.generate_tag.outputs.new_tag }}"
         body: "${{ steps.generate_tag.outputs.changelog }}"
-        token: ${{ secrets.EZ_TICKETS_APP_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload apks to google drive
       uses: mkrakowitzer/actions-googledrive@1
       with:


### PR DESCRIPTION

This PR uses GITHUB_TOKEN for token input in upload release artifacts action

Signed-off-by: arafaysaleem <a.rafaysaleem@gmail.com>