### PR TITLE
ci(Actions): Fix download directory paths for artifacts

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -92,7 +92,7 @@ documentation:
   - any: ['README.md','doc/**/*']
 
 chores:
-  - any: ['.gitignore']
+  - any: ['.gitignore','README.md','.github/**/*']
 
 native/android:
   - any: ['android/**/*']

--- a/.github/workflows/PR-merge-build-release.yaml
+++ b/.github/workflows/PR-merge-build-release.yaml
@@ -70,16 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download Keystore Artifact
+      - name: Download Keystore & Properties Artifact
         uses: actions/download-artifact@v2.0.9
         with:
           name: signing-key-artifact #Must be same as upload artifact in previous job
-          path: ./android/${{ secrets.KEYSTORE_FILENAME }}
-      - name: Download Key Properties Artifact
-        uses: actions/download-artifact@v2.0.9
-        with:
-          name: signing-key-artifact #Must be same as upload artifact in previous job
-          path: ./android/key.properties
+          path: android #Download to android directory
       - uses: actions/setup-java@v1
         with:
           java-version: '12.x'
@@ -91,9 +86,9 @@ jobs:
         run: flutter pub get
       - name: Run build runner for codegen files
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
-      - name: Generate splitted release apks
+      - name: Generate Splitted Release APKs
         run: flutter build apk --target-platform android-arm,android-arm64 --split-per-abi --obfuscate --split-debug-info=./ez_tickets_app/debug_trace
-      - name: Upload Key Properties Artifact
+      - name: Upload Built APKs Artifact
         uses: actions/upload-artifact@v2.2.3
         with:
           name: built-apks-artifact
@@ -117,7 +112,7 @@ jobs:
         uses: actions/download-artifact@v2.0.9
         with:
           name: built-apks-artifact #Must be same as upload artifact in previous job
-          path: 'build/app/outputs/flutter-apk/*.apk'
+          path: build/app/outputs/flutter-apk #download all apks to flutter-apk dir
       - name: Upload release apk to artifacts
         uses: ncipollo/release-action@v1.8.6
         with:
@@ -136,7 +131,7 @@ jobs:
         uses: actions/download-artifact@v2.0.9
         with:
           name: built-apks-artifact #Must be same as upload artifact in previous job
-          path: 'build/app/outputs/flutter-apk/*.apk'
+          path: build/app/outputs/flutter-apk #download all apks to flutter-apk dir
       - name: Upload apks to google drive
         uses: mkrakowitzer/actions-googledrive@1
         with:


### PR DESCRIPTION
### Issue ###
Previously, listing of full filename in paths of download-artifact created a directory instead of that file.
### Fix ###
This PR changes the paths to parent directory names and removes duplicate artifact downloads

Signed-off-by: arafaysaleem <a.rafaysaleem@gmail.com>